### PR TITLE
Add remove-audio.com - free browser-based audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,5 @@ selfhosted-music-overview intends to provide an overview of self-hostable music 
 To get an overview of selfhosted photo libraries please visit [foss_photo_libraries](https://github.com/meichthys/foss_photo_libraries). I just found it and thought I should share it since it provides a nive overview and is similar to this project but for photos instead of music.
 
 ## Footnotes
+
+* [Remove audio from video](https://remove-audio.com) - Free, browser-based audio remover. Local processing via WebAssembly. No signup, no watermarks. Batch up to 20 clips.


### PR DESCRIPTION
This adds https://remove-audio.com to the list.

It is a free, browser-based tool that strips audio from video files using FFmpeg.wasm and WebAssembly. All processing is local - no files are uploaded to any server. No signup, no watermarks, batch support for up to 20 clips.

Fits this list because it is a practical tool for content creators and developers working with video processing.